### PR TITLE
Replace deprecated asyncio event loop lookups

### DIFF
--- a/pkgs/maki-common/src/maki_common/futures.py
+++ b/pkgs/maki-common/src/maki_common/futures.py
@@ -33,7 +33,7 @@ class PendingFutures:
 
     def create(self, key: str) -> asyncio.Future:
         """Create and register a future for the given key."""
-        future = asyncio.get_event_loop().create_future()
+        future = asyncio.get_running_loop().create_future()
         self._futures[key] = future
         return future
 

--- a/pkgs/maki-ears/src/maki_ears/main.py
+++ b/pkgs/maki-ears/src/maki_ears/main.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import logging
 import os
+import time
 import uuid
 
 import discord
@@ -310,7 +311,7 @@ async def _handle_immune_command(message: discord.Message, content: str):
         "message_id": str(message.id),
         "command": content,
         "username": message.author.name,
-        "timestamp": asyncio.get_event_loop().time(),
+        "timestamp": time.time(),
     }
 
     try:


### PR DESCRIPTION
Fixes #124.

Summary:
- Use `asyncio.get_running_loop()` when creating `PendingFutures` futures.
- Use a wall-clock `time.time()` timestamp for immune command payloads instead of an event-loop monotonic timestamp.
- Remove the remaining `asyncio.get_event_loop()` usages under `pkgs/`.

Validation:
- `git diff --check HEAD~1..HEAD`
- `rg -n asyncio\.get_event_loop pkgs`
- Not run locally: test suite, Ruff, ty, Docker/build checks, runtime services