### PR TITLE
Fix issue pagination after PR-only pages

### DIFF
--- a/pkgs/maki-common/src/maki_common/github_client.py
+++ b/pkgs/maki-common/src/maki_common/github_client.py
@@ -128,9 +128,6 @@ class GitHubIssueClient:
                 # Filter out pull requests (GitHub API returns PRs as issues too)
                 batch = [i for i in raw if "pull_request" not in i]
 
-                if not batch:
-                    break
-
                 issues.extend(batch)
 
                 # If we got fewer than a full page, we've exhausted the results

--- a/pkgs/maki-common/tests/test_github_client.py
+++ b/pkgs/maki-common/tests/test_github_client.py
@@ -273,6 +273,23 @@ def test_list_issues_paginates_and_sorts_by_priority():
     assert priorities == sorted(priorities, key=lambda p: {"P1": 1, "P3": 3, "P5": 5}[p])
 
 
+def test_list_issues_continues_after_full_pull_request_page():
+    page1 = [{"number": i, "pull_request": {}, "labels": []} for i in range(100)]
+    page2 = [{"number": 1000, "labels": [{"name": "P2"}]}]
+    requested_pages: list[str] = []
+    pages = iter([page1, page2])
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested_pages.append(request.url.params["page"])
+        return httpx.Response(200, json=next(pages))
+
+    client = _make_client(handler)
+    issues = _run(client.list_issues())
+
+    assert [i["number"] for i in issues] == [1000]
+    assert requested_pages == ["1", "2"]
+
+
 def test_list_issues_empty_on_http_error():
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(500)


### PR DESCRIPTION
Fixes #248.

## Summary
- keep paginating `list_issues()` when a full GitHub API page contains only pull requests
- continue using the raw page size as the exhaustion signal
- add a regression that starts with a PR-only page and verifies the next issue page is fetched

## Validation
- `git diff --check`
- Not run locally
